### PR TITLE
EXCEPTION CAUSED BY TYPO FIX

### DIFF
--- a/lib/Bugherd/Client.php
+++ b/lib/Bugherd/Client.php
@@ -207,7 +207,7 @@ class Client
      * @param  boolean $check
      * @return Client
      */
-    public function setCheckSslCertificate($check = tue)
+    public function setCheckSslCertificate($check = true)
     {
         $this->checkSslCertificate = $check;
 


### PR DESCRIPTION
Fixed a typo that caused a hard error on PHP 7.2